### PR TITLE
Pass remounts => false to mount resources

### DIFF
--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -87,12 +87,13 @@ define gluster::mount (
   $_options = join(delete($mount_options, ''), ',')
 
   mount { $title:
-    ensure  => $ensure,
-    atboot  => $atboot,
-    device  => $volume,
-    fstype  => 'glusterfs',
-    dump    => $dump,
-    pass    => $pass,
-    options => $_options,
+    ensure   => $ensure,
+    fstype   => 'glusterfs',
+    remounts => false,
+    atboot   => $atboot,
+    device   => $volume,
+    dump     => $dump,
+    pass     => $pass,
+    options  => $_options,
   }
 }


### PR DESCRIPTION
As identified in #10, a refresh of a volume will attempt to remount the
volume but the FUSE client does not support this.  Set
[remounts](https://docs.puppetlabs.com/references/3.4.stable/type.html#mount-attribute-remounts) to `false` on the mount resource.

This means that any resource changes will cause the mount to be
**unmounted** and then mounted.