### PR TITLE
_netdev is not required for glusterfs.

### DIFF
--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -83,7 +83,7 @@ define gluster::mount (
     fail("Unknown option ${ensure} for ensure")
   }
 
-  $mount_options = [ "_netdev", "${options}", "${ll}", "${lf}", "${t}", "${dim}", "${r}", ]
+  $mount_options = [ "${options}", "${ll}", "${lf}", "${t}", "${dim}", "${r}", ]
   $_options = join(delete($mount_options, ''), ',')
 
   mount { $title:


### PR DESCRIPTION
_netdev is only for filesystems that represent themselves like a block device, where mount is unable to know that the mount depends on network, like iscsi devices.
glusterfs is a specific type of filesystem, mount know that glusterfs can only work with networking. Also see:
--- mount(80
_netdev
The filesystem resides on a device that requires network access (used to prevent the system from attempting to mount these filesystems until the network has been enabled on the system).