### PR TITLE
Making sure the mountpoint exists.

### DIFF
--- a/examples/04_hiera.md
+++ b/examples/04_hiera.md
@@ -67,7 +67,7 @@ If you would like to specify mounts in hiera, you can add items on `/etc/puppet/
 To create these mounts, add a class to the host with this content:
 
     class profile::gluster {
-      create_resources('gluster::mount', hiera_hash("gluster_mounts"), {})
+      create_resources('gluster::mount', hiera_hash("gluster_mounts", {}))
     }
 
-Mounts can be described in mutiple layers, hiera_hash will collect them and create_resources will make all mounts.
+Mounts can be described in mutiple layers, hiera_hash will collect them and create_resources will make all mounts. If no gluster_mounts are found, none are created.

--- a/examples/04_hiera.md
+++ b/examples/04_hiera.md
@@ -51,3 +51,23 @@ If you support multiple major versions of Red Hat (and derivative) systems, you 
     gluster::version: "3.5.2-1.el%{::operatingsystemmajrelease}"
 
 Hiera will interepret the value of `%{::operatingsystemmajrelease}` as a fact of the same name, and replace the Red Hat major version number in this string.
+
+If you would like to specify mounts in hiera, you can add items on `/etc/puppet/hieradata/common.yaml` or any other (more specific) layer:
+
+    ---
+    gluster_mounts:
+      /mountpoint:
+        volume: hostname:/volume
+        ensure: mounted
+
+  - /mountpoint should be replaced by the path where you would like this gluster resource to be mounted.
+  - hostname should be replaced by the hostname/ip of the machine offering this gluster volume.
+  - /volume should be replaced by the volume available on the gluster server.
+
+To create these mounts, add a class to the host with this content:
+
+    class profile::gluster {
+      create_resources('gluster::mount', hiera_hash("gluster_mounts"), {})
+    }
+
+Mounts can be described in mutiple layers, hiera_hash will collect them and create_resources will make all mounts.

--- a/manifests/mount.pp
+++ b/manifests/mount.pp
@@ -85,6 +85,10 @@ define gluster::mount (
 
   $mount_options = [ "${options}", "${ll}", "${lf}", "${t}", "${dim}", "${r}", ]
   $_options = join(delete($mount_options, ''), ',')
+  
+  file { $title:
+    ensure => directory,
+  }
 
   mount { $title:
     ensure   => $ensure,


### PR DESCRIPTION
If you want to allow this module to mount on any location, the mountpoint ($title) needs to exist as a directory. This addition creates the directory.
As Puppet can't do 'mkdir -p', (https://groups.google.com/forum/#!topic/puppet-users/1N0KMmurhcI) there is a limitation; the parent directories need to exist.