### PR TITLE
Fix reuse of variable name in volume.pp

### DIFF
--- a/manifests/volume.pp
+++ b/manifests/volume.pp
@@ -261,8 +261,8 @@ define gluster::volume (
           if $remove_options {
             create_resources( ::gluster::volume::option, $remove )
           } else {
-            $r = join( keys($remove), ', ' )
-            notice("NOT REMOVING the following options for volume ${title}: ${r}.")
+            $remove_str = join( keys($remove), ', ' )
+            notice("NOT REMOVING the following options for volume ${title}:${remove_str}.")
           }
         }
         if ! empty($to_add) {


### PR DESCRIPTION
Commit fixes reuse of variable name in volume.pp. Variable name $r has been used
earlier to store replica information earlier and been (re)used to store
information about removed options later. Such thing is prohibited by Puppet.

Closes covermymeds/puppet-gluster#18